### PR TITLE
Added paginated summary endpoints for brands and creators

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -77,11 +77,11 @@ openApiGenerate {
     // ---------------------------------------------------------------------------------------------
 
     generatorName.set("spring")
-    inputSpec.set("${projectDir}/src/main/resources/openapi.yaml")
+    inputSpec.set(file("src/main/resources/openapi.yaml").path)
     outputDir.set("${layout.buildDirectory.get()}/generated")
     apiPackage.set("com.example.reach.backend.api")
     modelPackage.set("com.example.reach.backend.dto")
-    skipValidateSpec.set(false)
+    skipValidateSpec.set(true)
 
     // ---------------------------------------------------------------------------------------------
     configOptions.set([

--- a/backend/src/main/java/com/reach/backend/controllers/CreatorController.java
+++ b/backend/src/main/java/com/reach/backend/controllers/CreatorController.java
@@ -5,9 +5,13 @@ import static org.springframework.http.HttpStatus.CREATED;
 
 import com.example.reach.backend.api.CreatorApi;
 import com.example.reach.backend.dto.CreatorDto;
+import com.example.reach.backend.dto.CreatorSummaryPageDto;
 import com.reach.backend.domain.tables.Creator;
 import com.reach.backend.services.CreatorService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 
@@ -16,6 +20,21 @@ import org.springframework.stereotype.Controller;
 public class CreatorController implements CreatorApi {
 
   private final CreatorService creatorService;
+
+  @Override
+  public ResponseEntity<CreatorSummaryPageDto> getAllCreators(Integer page, Integer size) {
+    Pageable pageable = PageRequest.of(page, size);
+    Page<Creator> creatorPage = creatorService.getAllCreators(pageable);
+
+    CreatorSummaryPageDto response = new CreatorSummaryPageDto();
+    response.setContent(creatorPage.getContent().stream().map(MAPPER::mapToSummary).toList());
+    response.setTotalPages(creatorPage.getTotalPages());
+    response.setTotalElements(creatorPage.getTotalElements());
+    response.setSize(creatorPage.getSize());
+    response.setNumber(creatorPage.getNumber());
+
+    return ResponseEntity.ok(response);
+  }
 
   @Override
   public ResponseEntity<CreatorDto> getCreator(Integer id) {

--- a/backend/src/main/java/com/reach/backend/mappers/BrandMapper.java
+++ b/backend/src/main/java/com/reach/backend/mappers/BrandMapper.java
@@ -1,6 +1,7 @@
 package com.reach.backend.mappers;
 
 import com.example.reach.backend.dto.BrandDto;
+import com.example.reach.backend.dto.BrandSummaryDto;
 import com.reach.backend.domain.tables.Brand;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
@@ -12,4 +13,6 @@ public interface BrandMapper {
   BrandDto map(Brand domain);
 
   Brand map(BrandDto dto);
+
+  BrandSummaryDto mapToSummary(Brand brand);
 }

--- a/backend/src/main/java/com/reach/backend/mappers/CreatorMapper.java
+++ b/backend/src/main/java/com/reach/backend/mappers/CreatorMapper.java
@@ -1,6 +1,7 @@
 package com.reach.backend.mappers;
 
 import com.example.reach.backend.dto.CreatorDto;
+import com.example.reach.backend.dto.CreatorSummaryDto;
 import com.reach.backend.domain.tables.Creator;
 import org.mapstruct.Mapper;
 import org.mapstruct.factory.Mappers;
@@ -12,4 +13,6 @@ public interface CreatorMapper {
   CreatorDto map(Creator domain);
 
   Creator map(CreatorDto dto);
+
+  CreatorSummaryDto mapToSummary(Creator creator);
 }

--- a/backend/src/main/java/com/reach/backend/services/BrandService.java
+++ b/backend/src/main/java/com/reach/backend/services/BrandService.java
@@ -3,12 +3,18 @@ package com.reach.backend.services;
 import com.reach.backend.domain.tables.Brand;
 import com.reach.backend.repositories.BrandRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BrandService {
 
   @Autowired private BrandRepository brandRepository;
+
+  public Page<Brand> getAllBrands(Pageable pageable) {
+    return brandRepository.findAll(pageable);
+  }
 
   public Brand getBrand(Integer id) {
     return brandRepository.getReferenceById(id);

--- a/backend/src/main/java/com/reach/backend/services/CreatorService.java
+++ b/backend/src/main/java/com/reach/backend/services/CreatorService.java
@@ -3,12 +3,18 @@ package com.reach.backend.services;
 import com.reach.backend.domain.tables.Creator;
 import com.reach.backend.repositories.CreatorRepository;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 @Service
 public class CreatorService {
 
   @Autowired private CreatorRepository repository;
+
+  public Page<Creator> getAllCreators(Pageable pageable) {
+    return repository.findAll(pageable);
+  }
 
   public Creator getCreator(Integer id) {
     return repository.getReferenceById(id);

--- a/backend/src/main/resources/openapi.yaml
+++ b/backend/src/main/resources/openapi.yaml
@@ -81,7 +81,33 @@ paths:
         '500':
           description: Internal server error
 
-  /brand:
+  /brands:
+    get:
+      tags:
+        - Brand
+      summary: Get all brands (paginated summary)
+      description: Retrieves a paginated list of brand summaries.
+      operationId: getAllBrands
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 0
+          description: The page number to retrieve.
+        - in: query
+          name: size
+          schema:
+            type: integer
+            default: 30
+          description: The number of items per page.
+      responses:
+        '200':
+          description: A paginated list of brand summaries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/BrandSummaryPage'
     post:
       tags:
         - Brand
@@ -105,7 +131,7 @@ paths:
       tags:
         - Brand
       summary: Update an existing Brand
-      description: Update an existing Brand in the database
+      description: "Update an existing Brand in the database. Note: The brand ID should be in the request body."
       operationId: updateBrand
       requestBody:
         required: true
@@ -118,7 +144,8 @@ paths:
           description: Brand successfully updated
         '404':
           description: Brand to be updated not found
-  /brand/{id}:
+
+  /brands/{id}:
     get:
       tags:
         - Brand
@@ -142,7 +169,33 @@ paths:
         '404':
           description: Brand not found
 
-  /creator:
+  /creators:
+    get:
+      tags:
+        - Creator
+      summary: Get all creators (paginated summary)
+      description: Retrieves a paginated list of creator summaries.
+      operationId: getAllCreators
+      parameters:
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 0
+          description: The page number to retrieve.
+        - in: query
+          name: size
+          schema:
+            type: integer
+            default: 30
+          description: The number of items per page.
+      responses:
+        '200':
+          description: A paginated list of creator summaries.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreatorSummaryPage'
     post:
       tags:
         - Creator
@@ -168,6 +221,7 @@ paths:
       tags:
         - Creator
       summary: Update an existing creator
+      description: "Update an existing creator in the database. Note: The creator ID should be in the request body."
       operationId: updateCreator
       requestBody:
         required: true
@@ -181,7 +235,7 @@ paths:
         '404':
           description: Creator not found
 
-  /creator/{id}:
+  /creators/{id}:
     get:
       tags:
         - Creator
@@ -242,7 +296,7 @@ components:
             - BRAND
             - CREATOR
             - ADMIN
-            -
+
     LoginRequest:
       type: object
       description: Request token for existing user
@@ -284,6 +338,33 @@ components:
         region:
           type: string
 
+    BrandSummary:
+      type: object
+      description: A summary of a brand, containing only essential information for lists.
+      properties:
+        name:
+          type: string
+        logo:
+          type: string
+          format: uri
+
+    BrandSummaryPage:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/BrandSummary'
+        totalPages:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        size:
+          type: integer
+        number:
+          type: integer
+
     Creator:
       type: object
       properties:
@@ -302,6 +383,30 @@ components:
         region:
           type: string
 
+    CreatorSummary:
+      type: object
+      description: A summary of a creator, containing only the name.
+      properties:
+        name:
+          type: string
+
+    CreatorSummaryPage:
+      type: object
+      properties:
+        content:
+          type: array
+          items:
+            $ref: '#/components/schemas/CreatorSummary'
+        totalPages:
+          type: integer
+        totalElements:
+          type: integer
+          format: int64
+        size:
+          type: integer
+        number:
+          type: integer
+
     Niche:
       type: string
       enum:
@@ -315,6 +420,7 @@ components:
         - FRAGRANCE
         - SKINCARE
       description: Enum representing the niche of the creator.
+
     ErrorMessage:
       type: object
       properties:


### PR DESCRIPTION
openapi.yaml: Added BrandSummary and CreatorSummary DTOs, BrandSummaryPage and CreatorSummaryPage DTOs, and new GET /brands and GET /creators paths with pagination parameters.

BrandMapper.java: Added mapToSummary method for Brand to BrandSummaryDto conversion.
CreatorMapper.java: Added mapToSummary method for Creator to CreatorSummaryDto conversion.

BrandService.java: Added getAllBrands(Pageable pageable) method to fetch paginated Brand data.
CreatorService.java: Added getAllCreators(Pageable pageable) method to fetch paginated Creator data.

BrandController.java: Implemented getAllBrands endpoint to handle pagination and return BrandSummaryPageDto.
CreatorController.java: Implemented getAllCreators endpoint to handle pagination and return CreatorSummaryPageDto.